### PR TITLE
Fixed Invalid JSON Format

### DIFF
--- a/src/tntrun/utils/Title.java
+++ b/src/tntrun/utils/Title.java
@@ -269,9 +269,9 @@ public class Title {
 				Object serialized = getMethod(nmsChatSerializer, "a",
 						String.class).invoke(
 						null,
-						"{text:\""
+						"{\"text\":\""
 								+ ChatColor.translateAlternateColorCodes('&',
-										title) + "\",color:"
+										title) + "\",\"color\":"
 								+ titleColor.name().toLowerCase() + "}");
 				packet = packetTitle.getConstructor(packetActions,
 						chatBaseComponent).newInstance(actions[0], serialized);
@@ -280,11 +280,11 @@ public class Title {
 					// Send subtitle if present
 					serialized = getMethod(nmsChatSerializer, "a", String.class)
 							.invoke(null,
-									"{text:\""
+									"{\"text\":\""
 											+ ChatColor
 													.translateAlternateColorCodes(
 															'&', subtitle)
-											+ "\",color:"
+											+ "\",\"color\":"
 											+ subtitleColor.name()
 													.toLowerCase() + "}");
 					packet = packetTitle.getConstructor(packetActions,

--- a/src/tntrun/utils/Title_1_7_R4.java
+++ b/src/tntrun/utils/Title_1_7_R4.java
@@ -247,9 +247,9 @@ public class Title_1_7_R4 {
 				Object serialized = getMethod(nmsChatSerializer, "a",
 						String.class).invoke(
 						null,
-						"{text:\""
+						"{\"text\":\""
 								+ ChatColor.translateAlternateColorCodes('&',
-										title) + "\",color:"
+										title) + "\",\"color\":"
 								+ titleColor.name().toLowerCase() + "}");
 				packet = packetTitle.getConstructor(packetActions,
 						getNMSClass("IChatBaseComponent")).newInstance(
@@ -259,11 +259,11 @@ public class Title_1_7_R4 {
 					// Send subtitle if present
 					serialized = getMethod(nmsChatSerializer, "a", String.class)
 							.invoke(null,
-									"{text:\""
+									"{\"text\":\""
 											+ ChatColor
 													.translateAlternateColorCodes(
 															'&', subtitle)
-											+ "\",color:"
+											+ "\",\"color\":"
 											+ subtitleColor.name()
 													.toLowerCase() + "}");
 					packet = packetTitle.getConstructor(packetActions,


### PR DESCRIPTION
On PaperSpigot 1.9 an error occoures when the plugin tries to send a JSON-formated Title to a player, e.g. on Arena Join:

```
[17:47:05] [Server thread/WARN]: java.lang.reflect.InvocationTargetException
[17:47:05] [Server thread/WARN]:    at sun.reflect.GeneratedMethodAccessor19.invoke(Unknown Source)
[17:47:05] [Server thread/WARN]:    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[17:47:05] [Server thread/WARN]:    at java.lang.reflect.Method.invoke(Method.java:498)
[17:47:05] [Server thread/WARN]:    at tntrun.utils.Title.send(Title.java:270)
[17:47:05] [Server thread/WARN]:    at tntrun.utils.TitleMsg.sendFullTitle(TitleMsg.java:36)
[17:47:05] [Server thread/WARN]:    at tntrun.arena.handlers.GameHandler.startEnding(GameHandler.java:425)
[17:47:05] [Server thread/WARN]:    at tntrun.arena.handlers.GameHandler.handlePlayer(GameHandler.java:299)
[17:47:05] [Server thread/WARN]:    at tntrun.arena.handlers.GameHandler$3.run(GameHandler.java:261)
[17:47:05] [Server thread/WARN]:    at org.bukkit.craftbukkit.v1_9_R1.scheduler.CraftTask.run(CraftTask.java:58)
[17:47:05] [Server thread/WARN]:    at org.bukkit.craftbukkit.v1_9_R1.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:352)
[17:47:05] [Server thread/WARN]:    at net.minecraft.server.v1_9_R1.MinecraftServer.D(MinecraftServer.java:822)
[17:47:05] [Server thread/WARN]:    at net.minecraft.server.v1_9_R1.DedicatedServer.D(DedicatedServer.java:404)
[17:47:05] [Server thread/WARN]:    at net.minecraft.server.v1_9_R1.MinecraftServer.C(MinecraftServer.java:723)
[17:47:05] [Server thread/WARN]:    at net.minecraft.server.v1_9_R1.MinecraftServer.run(MinecraftServer.java:622)
[17:47:05] [Server thread/WARN]:    at java.lang.Thread.run(Thread.java:745)
[17:47:05] [Server thread/WARN]: Caused by: com.google.gson.JsonSyntaxException: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3
[17:47:05] [Server thread/WARN]:    at com.google.gson.internal.Streams.parse(Streams.java:56)
[17:47:05] [Server thread/WARN]:    at com.google.gson.TreeTypeAdapter.read(TreeTypeAdapter.java:54)
[17:47:05] [Server thread/WARN]:    at net.minecraft.server.v1_9_R1.ChatDeserializer.a(SourceFile:501)
[17:47:05] [Server thread/WARN]:    at net.minecraft.server.v1_9_R1.ChatDeserializer.a(SourceFile:512)
[17:47:05] [Server thread/WARN]:    at net.minecraft.server.v1_9_R1.IChatBaseComponent$ChatSerializer.a(SourceFile:205)
[17:47:05] [Server thread/WARN]:    ... 15 more
[17:47:05] [Server thread/WARN]: Caused by: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3
[17:47:05] [Server thread/WARN]:    at com.google.gson.stream.JsonReader.syntaxError(JsonReader.java:1505)
[17:47:05] [Server thread/WARN]:    at com.google.gson.stream.JsonReader.checkLenient(JsonReader.java:1386)
[17:47:05] [Server thread/WARN]:    at com.google.gson.stream.JsonReader.doPeek(JsonReader.java:497)
[17:47:05] [Server thread/WARN]:    at com.google.gson.stream.JsonReader.hasNext(JsonReader.java:403)
[17:47:05] [Server thread/WARN]:    at com.google.gson.internal.bind.TypeAdapters$25.read(TypeAdapters.java:666)
[17:47:05] [Server thread/WARN]:    at com.google.gson.internal.bind.TypeAdapters$25.read(TypeAdapters.java:642)
[17:47:05] [Server thread/WARN]:    at com.google.gson.internal.Streams.parse(Streams.java:44)
[17:47:05] [Server thread/WARN]:    ... 19 more
```

To prevent this error you need to put the JSON-keys in quoutes.
I think it will worked with the changes in this pull request. Because you have dependencies to a paid plugin extension I was not able to compile the plugin and test the changes.
There is also a problem with you line breaks the java-files will appear here as complete changed. Changed were only made in the following lines:
Title.java:  272, 274, 283 and 287
Title_1_7_R4.java: 250, 252, 262 and 267
It would be fine if you update your plugin as fast as possible. 
